### PR TITLE
tokio || async-std, parsing of arbitrary responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,16 @@ categories = ["asynchronous", "network-programming"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-tokio = { version = "0.2", features = ["full"] }
 thiserror = "1.0"
+anyhow = "1.0"
+futures-util = { version = "0.3.1", default-features = false, features = ["io"], optional = true }
+tokio = { version = "0.2.9", default-features = false, features = ["io-util", "tcp"], optional = true }
+async-std = { version = "1.4.0", optional = true }
+
+[dev-dependencies]
+tokio = { version = "0.2.9", features = ["full"] }
+
+[features]
+default = ["runtime-tokio"]
+runtime-async-std = ["futures-util", "async-std"]
+runtime-tokio = ["tokio"]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,18 @@
+#[cfg(feature = "runtime-async-std")]
+#[allow(unused_imports)]
+pub(crate) use {
+    async_std::{
+        io::Error,
+        net::{TcpListener, TcpStream},
+    },
+    futures_util::io::{
+        AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter,
+    },
+};
+
+#[cfg(feature = "runtime-tokio")]
+#[allow(unused_imports)]
+pub(crate) use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter, Error},
+    net::{TcpListener, TcpStream},
+};


### PR DESCRIPTION
Tokio runtime is still the default.

Regarding parsing of arbitrary responses, here's how to get screenshots from Rigol DS1000Z series.

```rust
    async fn parse_binary_response(mut reader: Pin<&mut (dyn futures_util::io::AsyncBufRead + Send)>) -> Result<Vec<u8>, tokio_lxi::Error> {
        let mut buf = vec![0u8; 9];
        reader.read_exact(&mut buf[0..2]).await?;
        if buf[0] != b'#' {
            return Err(anyhow::Error::msg("First character is not '#' in binary response").into());
        }
        if !buf[1].is_ascii_digit() {
            return Err(anyhow::Error::msg(format!("Second character is not in 0..9 range: {} ({:02x})", char::from(buf[1]), buf[1])).into());
        }
        let digits = (buf[1] - b'0') as usize;
        reader.read_exact(&mut buf[0..digits]).await?;
        let length = u32::from_str_radix(String::from_utf8_lossy(&buf[0..digits]).as_ref(), 10)
            .map_err(|_| {
                anyhow::Error::msg("Can't parse data length")
            })?;

        let mut buf = vec![0u8; length as usize];
        reader.read_exact(&mut buf).await?;

        Ok(buf)
    }

    pub async fn get_screen(&mut self) -> Result<Vec<u8>, Error> {
        let conn: &mut LxiDevice = self.get_conn().await?;
        let image = conn.request_data("DISPLAY:DATA? OFF,OFF,BMP24", Self::parse_binary_response).await?;

        println!("Got screen data of {} bytes", image.len());
        Ok(image)
    }
```