### PR TITLE
dep updates, allow setting EOL string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-lxi"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Alexey Gerasev <alexey.gerasev@gmail.com>"]
 edition = "2018"
 
@@ -16,12 +16,12 @@ license = "MIT/Apache-2.0"
 [dependencies]
 thiserror = "1.0"
 anyhow = "1.0"
-futures-util = { version = "0.3.1", default-features = false, features = ["io"], optional = true }
-tokio = { version = "0.2.9", default-features = false, features = ["io-util", "tcp"], optional = true }
-async-std = { version = "1.4.0", optional = true }
+futures-util = { version = "0.3", default-features = false, features = ["io"], optional = true }
+tokio = { version = "1.10", optional = true }
+async-std = { version = "1.9", optional = true }
 
 [dev-dependencies]
-tokio = { version = "0.2.9", features = ["full"] }
+tokio = { version = "1.10", features = ["full"] }
 
 [features]
 default = ["runtime-tokio"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 
+const DEFAULT_EOL: &[u8] = b"\r\n";
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
@@ -33,6 +35,7 @@ fn remove_newline(text: &mut String) {
 
 pub struct LxiDevice {
     stream: Pin<Box<BufReader<BufWriter<TcpStream>>>>,
+    eol: Vec<u8>,
 }
 
 impl LxiDevice {
@@ -51,7 +54,12 @@ impl LxiDevice {
         );
         Ok(Self {
             stream: Box::pin(stream),
+            eol: DEFAULT_EOL.to_vec(),
         })
+    }
+
+    pub fn set_eol(&mut self, eol: &[u8]) {
+        self.eol = eol.to_vec();
     }
 
     async fn write<T: AsRef<[u8]>>(&mut self, buf: T) -> Result<(), Error> {
@@ -61,7 +69,7 @@ impl LxiDevice {
 
     pub async fn send(&mut self, req: &str) -> Result<(), Error> {
         self.write(req).await?;
-        self.stream.write_all(b"\r\n").await?;
+        self.stream.write_all(&self.eol).await?;
         self.stream.flush().await?;
         Ok(())
     }


### PR DESCRIPTION
Hello, I hacked together a stupid test/demo for my home hacklab and noticed that dependency updates would be nice, and most importantly, end of line handling should be tunable, so I did it.
My stupid code utilizing `tokio-lxi` can be found here:

[https://github.com/sjm42/my-hacklab-rs](https://github.com/sjm42/my-hacklab-rs)

An example run with actual hardware can be found here:

[https://gist.github.com/sjm42/c806d2289fea3caf973fafcacf42927b](https://gist.github.com/sjm42/c806d2289fea3caf973fafcacf42927b)

What do you think?
